### PR TITLE
Add gh repo clone command to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
       CHILD_CONCURRENCY: "1"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Clone repository
+        run: gh repo clone CasP0/vscode
 
       - uses: actions/setup-node@v2
         with:
@@ -28,9 +29,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "2.x"
-
-      - name: Clone repository
-        run: gh repo clone CasP0/vscode
 
       - name: Compute node modules cache key
         id: nodeModulesCacheKey
@@ -88,8 +86,6 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-
       - name: Clone repository
         run: gh repo clone CasP0/vscode
 
@@ -157,8 +153,6 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-
       - name: Clone repository
         run: gh repo clone CasP0/vscode
 
@@ -213,8 +207,6 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-
       - name: Clone repository
         run: gh repo clone CasP0/vscode
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,28 @@ gh pr checkout 237094
 
 This will create a new branch based on the pull request and switch to it.
 
+## Using `gh repo clone`
+
+The `gh repo clone` command allows you to clone a repository using GitHub CLI. This can be useful for quickly setting up a local copy of a repository.
+
+### Example
+
+To clone this repository, use the following command:
+
+```sh
+gh repo clone CasP0/vscode
+```
+
+This will create a local copy of the repository on your machine.
+
+### Benefits of using `gh repo clone`
+
+Using `gh repo clone` has several benefits over traditional `git clone`:
+
+1. **Simplified authentication**: The GitHub CLI handles authentication for you, so you don't need to manually configure SSH keys or access tokens.
+2. **Integration with GitHub CLI**: The `gh repo clone` command is part of the GitHub CLI, which provides additional functionality for managing repositories, issues, pull requests, and more.
+3. **Consistency**: Using `gh repo clone` ensures a consistent experience across different repositories and environments.
+
 ## Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Add a section in the `README.md` on how to use the `gh repo clone` command to clone the repository.

* **README.md**
  - Add a section on using `gh repo clone` with an example command.
  - Mention the benefits of using `gh repo clone` over traditional `git clone`.

* **.github/workflows/ci.yml**
  - Add a step to clone the repository using `gh repo clone` in the `windows`, `linux`, and `darwin` jobs.
  - Remove the existing `actions/checkout@v2` step from all jobs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CasP0/vscode/pull/6?shareId=fd37a29f-0059-4173-9422-3610b3cf7cd9).